### PR TITLE
fix entry point function name

### DIFF
--- a/src/sqlitejs.c
+++ b/src/sqlitejs.c
@@ -808,7 +808,7 @@ const char *sqlitejs_version (void) {
     return gversion;
 }
 
-APIEXPORT int sqlite3_sqlitejs_init (sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
+APIEXPORT int sqlite3_js_init (sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
     #ifndef SQLITE_CORE
     SQLITE_EXTENSION_INIT2(pApi);
     #endif

--- a/src/sqlitejs.h
+++ b/src/sqlitejs.h
@@ -16,7 +16,7 @@
 #include "sqlite3.h"
 #endif
 
-int sqlite3_sqlitejs_init (sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);
+int sqlite3_js_init (sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);
 const char *sqlitejs_version (void);
 
 #endif

--- a/test/sqlitejs/main.c
+++ b/test/sqlitejs/main.c
@@ -30,7 +30,7 @@ int main (void) {
     if (rc != SQLITE_OK) goto abort_test;
     
     // manually load extension
-    rc = sqlite3_sqlitejs_init(db, NULL, NULL);
+    rc = sqlite3_js_init(db, NULL, NULL);
     if (rc != SQLITE_OK) goto abort_test;
     
     printf("SQLite-JS version: %s\n\n", sqlitejs_version());


### PR DESCRIPTION
The entry point function name does not match the extension name. Here you can see the error while trying to load it.

![Screenshot 2025-04-09 alle 10 52 30](https://github.com/user-attachments/assets/2f1242c0-7a96-4cc7-9ac1-c23b0957492a)

With the changes in this pr the extension loads correctly.

![Screenshot 2025-04-09 alle 10 55 07](https://github.com/user-attachments/assets/98c7e7a0-9207-4349-ae61-f05e1135a2a2)


@marcobambini otherwise if we want to keep the old entry point function name we do have to change the library name in the makefile and in the readme.