### PR TITLE
fix(windows): require def file before link the final target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ $(shell mkdir -p $(BUILD_DIR) $(DIST_DIR))
 all: $(TARGET)
 
 # Link the final target
-$(TARGET): $(OBJ_FILES)
+$(TARGET): $(OBJ_FILES) $(DEF_FILE)
 	$(CC) $(LDFLAGS) -o $@ $^
 ifeq ($(PLATFORM),windows)
 	# Generate import library for Windows


### PR DESCRIPTION
dlltool needs the def file to compile, without the def file it throws an error and doesn't let me compile the library